### PR TITLE
Fixed critical error in entity draw order

### DIFF
--- a/Raycaster.cpp
+++ b/Raycaster.cpp
@@ -469,9 +469,11 @@ namespace sfray {
                         continue;
                     }
                     // are other walls in front
-                    if (transformY > mZBuffer[stripe]){
-                        drawStartX += 1;
-                        continue;
+                    if (stripe < mZBuffer.size()) {
+                        if (transformY > mZBuffer[stripe]) {
+                            drawStartX += 1;
+                            continue;
+                        }
                     }
 
                     break;
@@ -489,9 +491,11 @@ namespace sfray {
                         continue;
                     }
 
-                    if (transformY > mZBuffer[stripe]){
-                        drawEndX -= 1;
-                        continue;
+                    if (stripe < mZBuffer.size()) {
+                        if (transformY > mZBuffer[stripe]) {
+                            drawEndX -= 1;
+                            continue;
+                        }
                     }
 
                     break;

--- a/ResourcePath.hpp
+++ b/ResourcePath.hpp
@@ -4,7 +4,7 @@
 #include <string>
 
 static std::string resourcePath() {
-	return "";
+	return "resources/";
 }
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -137,7 +137,7 @@ int main(int, char const**)
     sf::Text fps_text;
     fps_text.setFont(font);
     fps_text.setCharacterSize(32);
-    fps_text.setColor(sf::Color::Yellow);
+    fps_text.setFillColor(sf::Color::Yellow);
     fps_text.setPosition(10, 10);
 
     sf::Texture overlayTexture;


### PR DESCRIPTION
- Fixed subscript vector out of range critical error when drawing the entities. So I added checks in order to avoid the mZBuffer to get out of range.
- Change the setColor method in main.cpp for setFillColor in order to adapt it to SFML 2.6.1
- Change resource path in order to adjust it to the repo structure.